### PR TITLE
wpsf_get_setting  bug

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -966,8 +966,8 @@ if( !function_exists('wpsf_get_setting') ){
      */
     function wpsf_get_setting( $option_group, $section_id, $field_id ){
         $options = get_option( $option_group .'_settings' );
-        if(isset($options[$option_group .'_'. $section_id .'_'. $field_id])){
-            return $options[$option_group .'_'. $section_id .'_'. $field_id];
+        if(isset($options[$section_id .'_'. $field_id])){
+            return $options[$section_id .'_'. $field_id];
         }
         return false;
     }


### PR DESCRIPTION
wpsf_get_setting  checks if option is set but in error is adding option_group to the array index in the isset & return command.  option group is not in the array index