### PR TITLE
Update wp-settings-framework.php

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -453,8 +453,10 @@ if( !class_exists('WordPressSettingsFramework') ){
         public function generate_time_field( $args ) {
 
             $args['value'] = esc_attr( stripslashes( $args['value'] ) );
+            
+            $tp=(isset($args['timepicker']))?htmlentities( json_encode( $args['timepicker'] ) ):'null';
 
-            echo '<input name="'. $args['name'] .'" id="'. $args['id'] .'" value="'. $args['value'] .'" class="timepicker regular-text '. $args['class'] .'" data-timepicker="'.htmlentities( json_encode( $args['timepicker'] ) ).'" />';
+            echo '<input name="'. $args['name'] .'" id="'. $args['id'] .'" value="'. $args['value'] .'" class="timepicker regular-text '. $args['class'] .'" data-timepicker="'.$tp.'" />';
 
             $this->generate_description( $args['desc'] );
 
@@ -468,8 +470,10 @@ if( !class_exists('WordPressSettingsFramework') ){
         public function generate_date_field( $args ) {
 
             $args['value'] = esc_attr( stripslashes( $args['value'] ) );
+            
+            $dp=(isset($args['datepicker']))?htmlentities( json_encode( $args['datepicker'] ) ):'null';
 
-            echo '<input name="'. $args['name'] .'" id="'. $args['id'] .'" value="'. $args['value'] .'" class="datepicker regular-text '. $args['class'] .'" data-datepicker="'.htmlentities( json_encode( $args['datepicker'] ) ).'" />';
+            echo '<input name="'. $args['name'] .'" id="'. $args['id'] .'" value="'. $args['value'] .'" class="datepicker regular-text '. $args['class'] .'" data-datepicker="'.$dp'" />';
 
             $this->generate_description( $args['desc'] );
 


### PR DESCRIPTION
Check for variables being set in date & time picker to avoid PHP warnings