### PR TITLE
1. Fix for PHP Deprecated: Unparenthesized `a ? b : c ? d : e` is dep…

### DIFF
--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -69,6 +69,14 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'type'       => 'group',
 				'subfields' => array(
 					// accepts most types of fields
+					array(
+						'id'          => 'sub-text',
+						'title'       => 'Sub Text',
+						'desc'        => 'This is a description.',
+						'placeholder' => 'This is a placeholder.',
+						'type'        => 'text',
+						'default'     => 'Sub text',
+					),
 				)
 			),
 			array(

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -429,7 +429,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		 * @param array $args
 		 */
 		public function generate_group_field( $args ) {
-			$row_count = count( $args['value'] );
+			$row_count = count( $args['subfields'] );
 
 			echo '<table class="widefat wpsf-group" cellspacing="0">';
 
@@ -472,7 +472,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 				foreach ( $args['subfields'] as $subfield ) {
 					$subfield = wp_parse_args( $subfield, $this->setting_defaults );
 
-					$subfield['value'] = ( $blank ) ? "" : isset( $args['value'][ $row ][ $subfield['id'] ] ) ? $args['value'][ $row ][ $subfield['id'] ] : "";
+					$subfield['value'] = ( $blank ) ? "" : ( isset( $args['value'][ $row ][ $subfield['id'] ] ) ? $args['value'][ $row ][ $subfield['id'] ] : "" );
 					$subfield['name']  = sprintf( '%s[%d][%s]', $args['name'], $row, $subfield['id'] );
 					$subfield['id']    = sprintf( '%s_%d_%s', $args['id'], $row, $subfield['id'] );
 

--- a/wpsf-test.php
+++ b/wpsf-test.php
@@ -26,7 +26,7 @@ class WPSFTest {
 
 		// Include and create a new WordPressSettingsFramework
 		require_once( $this->plugin_path . 'wp-settings-framework.php' );
-		$this->wpsf = new WordPressSettingsFramework( $this->plugin_path . 'settings/settings-general.php', 'prefix_settings_general' );
+		$this->wpsf = new WordPressSettingsFramework( $this->plugin_path . 'settings/example-settings.php', 'my_example_settings' );
 
 		// Add admin menu
 		add_action( 'admin_menu', array( $this, 'add_settings_page' ), 20 );
@@ -38,7 +38,7 @@ class WPSFTest {
 	/**
 	 * Add settings page.
 	 */
-	public function settings_page() {
+	public function add_settings_page() {
 		$this->wpsf->add_settings_page( array(
 			'parent_slug' => 'woocommerce',
 			'page_title'  => __( 'Page Title', 'text-domain' ),


### PR DESCRIPTION
…recated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in /home/xxxxxxxxxxxxxxxxx/staging/1/wp-content/plugins/show-single-variations-premium/inc/vendor/wp-settings-framework/wp-settings-framework.php on line 475

2. Corrected plugin's option group

3. Fix warnings