### PR TITLE
Remove requirement of settings file

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		/**
 		 * WordPressSettingsFramework constructor.
 		 *
-		 * @param null|string $settings_file Path to a settings file, or null if you want to pass the option_group manually.
+		 * @param null|string $settings_file Path to a settings file, or null if you pass the option_group manually and construct your settings with a filter.
 		 * @param bool|string $option_group Option group name, usually a short slug.
 		 */
 		public function __construct( $settings_file = null, $option_group = false ) {

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -74,20 +74,24 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 		/**
 		 * WordPressSettingsFramework constructor.
 		 *
-		 * @param string $settings_file
-		 * @param bool   $option_group
+		 * @param null|string $settings_file Path to a settings file, or null if you want to pass the option_group manually.
+		 * @param bool|string $option_group Option group name, usually a short slug.
 		 */
-		public function __construct( $settings_file, $option_group = false ) {
-			if ( ! is_file( $settings_file ) ) {
-				return;
+		public function __construct( $settings_file = null, $option_group = false ) {
+			$this->option_group = $option_group;
+
+			if ( $settings_file ) {
+				if ( ! is_file( $settings_file ) ) {
+					return;
+				}
+
+				require_once( $settings_file );
+
+				$this->option_group = preg_replace( "/[^a-z0-9]+/i", "", basename( $settings_file, '.php' ) );
 			}
 
-			require_once( $settings_file );
-
-			$this->option_group = preg_replace( "/[^a-z0-9]+/i", "", basename( $settings_file, '.php' ) );
-
-			if ( $option_group ) {
-				$this->option_group = $option_group;
+			if ( empty( $this->option_group ) ) {
+				return;
 			}
 
 			$this->options_path = plugin_dir_path( __FILE__ );

--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -87,7 +87,9 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
 
 				require_once( $settings_file );
 
-				$this->option_group = preg_replace( "/[^a-z0-9]+/i", "", basename( $settings_file, '.php' ) );
+				if ( ! $this->option_group ) {
+					$this->option_group = preg_replace( "/[^a-z0-9]+/i", "", basename( $settings_file, '.php' ) );
+				}
 			}
 
 			if ( empty( $this->option_group ) ) {


### PR DESCRIPTION
You can init the settings without passing a settings file, then simply add a filter to form the settings array.