### PR TITLE
replace $.live with $.on to keep the compatiblity with WordPress 5.5

### DIFF
--- a/wp-settings-framework.php
+++ b/wp-settings-framework.php
@@ -631,10 +631,10 @@ if ( ! class_exists( 'WordPressSettingsFramework' ) ) {
                     var colorPicker = $("#' . $color_picker_id . '");
                     colorPicker.farbtastic("#' . $args['id'] . '");
                     colorPicker.hide();
-                    $("#' . $args['id'] . '").live("focus", function(){
+                    $("#' . $args['id'] . '").on("focus", function(){
                         colorPicker.show();
                     });
-                    $("#' . $args['id'] . '").live("blur", function(){
+                    $("#' . $args['id'] . '").on("blur", function(){
                         colorPicker.hide();
                         if($(this).val() == "") $(this).val("#");
                     });


### PR DESCRIPTION
Note: [WordPress 5.5 removes jQuery migrate 1.x](https://make.wordpress.org/core/2020/06/29/updating-jquery-version-shipped-with-wordpress/)
