### PR TITLE
Initially date picker throws error in console #1

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -200,8 +200,12 @@
 		setup_datepickers: function() {
 			$( document ).on( 'focus',  '.datepicker:not(.hasTimepicker)', function() {
 				var datepicker_args = $( this ).data( 'datepicker' );
-
+				// It throws an error if empty string is passed.
+				if ( '' === datepicker_args ) {
+					datepicker_args = {};
+				}
 				$( this ).datepicker( datepicker_args );
+
 			} );
 
 			// Empty altField if datepicker field is emptied.


### PR DESCRIPTION
If `data-picker` attribute is empty in settings as default the date picker is not initializing.

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/17900945/227196219-ff704a44-a8fc-40bf-9bcb-e6599449214b.png">
