### PR TITLE
bugfix: dropdown choices hides description issue

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -221,14 +221,38 @@
 		/**
 		 * Set up selects
 		 */
-		setup_selects: function() {
-			// Show/Hide descriptions based on selected value.
-			$( document ).on( 'change', '.form-table select', function() {
-				var value = $(this).val();
-				$(this).siblings( '.wpsf-description' ).hide();
-				$(this).siblings( `.wpsf-description[data-value="${value}"]` ).show();
-			});
-		},
+
+setup_selects: function() {
+    $( document ).on( 'change', '.form-table select', function() {
+        var value = $(this).val() ?? '';
+        var $allDescriptions = $(this).siblings( '.wpsf-description' );
+        
+        // Only processing this, if there are multiple descriptions
+        // (which indicates conditional_desc is being used)
+        if ($allDescriptions.length <= 1) {
+            // Only one description = just the main desc, don't touch it!
+            return;
+        }
+        
+        // Multiple descriptions exist, so manage visibility
+        var $valueDescriptions = $allDescriptions.filter( '[data-value]' );
+        var $defaultDescription = $allDescriptions.not('[data-value]');
+
+        if ( $valueDescriptions.length > 0 ) {
+            // Hide only the conditional descriptions, NOT the default one
+            $valueDescriptions.hide();
+            
+            var $target = $valueDescriptions.filter( '[data-value="' + value + '"]' );
+            
+            if ( $target.length > 0 ) {
+                $target.show();
+            }
+            
+            // Always keep the default description visible
+            $defaultDescription.show();
+        }
+    });
+},
 
 		/**
 		 * Setup repeatable groups

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -222,37 +222,37 @@
 		 * Set up selects
 		 */
 
-setup_selects: function() {
-    $( document ).on( 'change', '.form-table select', function() {
-        var value = $(this).val() ?? '';
-        var $allDescriptions = $(this).siblings( '.wpsf-description' );
-        
-        // Only processing this, if there are multiple descriptions
-        // (which indicates conditional_desc is being used)
-        if ($allDescriptions.length <= 1) {
-            // Only one description = just the main desc, don't touch it!
-            return;
-        }
-        
-        // Multiple descriptions exist, so manage visibility
-        var $valueDescriptions = $allDescriptions.filter( '[data-value]' );
-        var $defaultDescription = $allDescriptions.not('[data-value]');
+		setup_selects: function() {
+			$( document ).on( 'change', '.form-table select', function() {
+				var value = $(this).val() ?? '';
+				var $allDescriptions = $(this).siblings( '.wpsf-description' );
+				
+				// Only processing this, if there are multiple descriptions
+				// (which indicates conditional_desc is being used)
+				if ($allDescriptions.length <= 1) {
+					// Only one description = just the main desc, don't touch it!
+					return;
+				}
+				
+				// Multiple descriptions exist, so manage visibility
+				var $valueDescriptions = $allDescriptions.filter( '[data-value]' );
+				var $defaultDescription = $allDescriptions.not('[data-value]');
 
-        if ( $valueDescriptions.length > 0 ) {
-            // Hide only the conditional descriptions, NOT the default one
-            $valueDescriptions.hide();
-            
-            var $target = $valueDescriptions.filter( '[data-value="' + value + '"]' );
-            
-            if ( $target.length > 0 ) {
-                $target.show();
-            }
-            
-            // Always keep the default description visible
-            $defaultDescription.show();
-        }
-    });
-},
+				if ( $valueDescriptions.length > 0 ) {
+					// Hide only the conditional descriptions, NOT the default one
+					$valueDescriptions.hide();
+					
+					var $target = $valueDescriptions.filter( '[data-value="' + value + '"]' );
+					
+					if ( $target.length > 0 ) {
+						$target.show();
+					}
+					
+					// Always keep the default description visible
+					$defaultDescription.show();
+				}
+			});
+		},
 
 		/**
 		 * Setup repeatable groups

--- a/settings/example-settings.php
+++ b/settings/example-settings.php
@@ -286,6 +286,17 @@ function wpsf_tabless_settings( $wpsf_settings ) {
 				'default'  => 'text',
 			),
 			array(
+					'id'          => 'choice_bug_text',
+					'type'        => 'select',
+					'title'       => 'test bug',
+					'desc'        => 'sample description',
+					'default'     => 'mask',
+					'choices'     => array(
+						'option1'  => 'Option One',
+						'option2'  => 'Option Two',
+					),
+			),
+			array(
 				'id'       => 'show-if-option-1',
 				'title'    => 'Show if Option 1',
 				'subtitle' => 'Will show if Option 1 is set.',


### PR DESCRIPTION
fix issue where the description hides automatically after changing drop-down choice.

Earlier: Description Hides automatically on changing option choice.

<img width="798" height="465" alt="1 " src="https://github.com/user-attachments/assets/a913285f-65c5-46f0-bb98-4a81ec1d3c04" />
<img width="798" height="465" alt="2" src="https://github.com/user-attachments/assets/15ca146b-8a7b-4498-951f-a54863c5729a" />

After Updating `setup_selects` function in javascript: Description is visible even after changing choice.

<img width="798" height="465" alt="3" src="https://github.com/user-attachments/assets/806b3803-89a9-49ce-8dcf-2a831e7bf626" />
<img width="798" height="465" alt="4" src="https://github.com/user-attachments/assets/95a84a00-9f39-4c30-ba38-a42fd61c741b" />
